### PR TITLE
Add new rule to optimize comprehension for assignements

### DIFF
--- a/code_example/trolley_shorten.py
+++ b/code_example/trolley_shorten.py
@@ -3,6 +3,6 @@ n=int(V())
 Z=float('inf')
 Y=0
 for i in range(n):
- q,v=[int(j)for j in V().split()]
+ q,v=map(int,V().split())
  if q*v<Z:Z=q*v;Y=i+1
 print(Y)

--- a/pygolf/optimization_phases/always_apply_phase.py
+++ b/pygolf/optimization_phases/always_apply_phase.py
@@ -11,3 +11,4 @@ class AlwaysApplyPhase(Phase):
     def generate_rules(self, ast: NodeNG) -> Iterator[AstroidRule]:
         yield FormatToFString()
         yield RangeForToComprehensionFor()
+        yield ComprehensionForAssignToMapAssign()

--- a/pygolf/rules/__init__.py
+++ b/pygolf/rules/__init__.py
@@ -4,6 +4,7 @@ from .version import Version
 
 __all__: List[str] = [
     "AstroidRule",
+    "ComprehensionForAssignToMapAssign",
     "DefineRenameCall",
     "FormatToFString",
     "RangeForToComprehensionFor",

--- a/test/rules/test_rules.py
+++ b/test/rules/test_rules.py
@@ -9,6 +9,18 @@ from pygolf.unparser import Unparser
 unparser = Unparser()
 
 
+class TestComprehensionForAssignToMapAssign(unittest.TestCase):
+    def test_rule(self):
+        with register_rule(ComprehensionForAssignToMapAssign()) as transformer:
+            node = transformer.visit(astroid.parse("x,y=[int(j) for j in input().split()]"))
+            unparsed = unparser.unparse(node)
+            self.assertEqual(unparsed, "x,y=map(int,input().split())")
+
+            node = transformer.visit(astroid.parse("x,y=[f(j, 1) for j in input().split()]"))
+            unparsed = unparser.unparse(node)
+            self.assertEqual(unparsed, "x,y=[f(j,1)for j in input().split()]")
+
+
 class TestDefineRenameCall(unittest.TestCase):
     def test_rule(self):
         with register_rule(DefineRenameCall("method_name", "new_method_name")) as transformer:


### PR DESCRIPTION
This aims to replace the way codingame is usually reading inputs:

`x,y=[int(i) for i in input().split()]`

to

`x,y=map(int,input().split())`

Saving 9 characters